### PR TITLE
:tada: introduce :filter and :update_expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Logstash Plugin
+# Logstash Mongo Output Plugin
 
-[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-output-mongodb.svg)](https://travis-ci.org/logstash-plugins/logstash-output-mongodb)
+---
+This is a fork of [logstash-plugins/logstash-output-mongodb](https://github.com/logstash-plugins/logstash-output-mongodb).
+
+It adds the :action, :filter, :update_expressions and :upsert parameters
+---
 
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
@@ -21,20 +25,17 @@ Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/log
 
 ### 1. Plugin Developement and Testing
 
-#### Code
-- To get started, you'll need JRuby with the Bundler gem installed.
+For developing this plugin we use the wonderful work of [cameronkerrnz/logstash-plugin-dev](https://github.com/cameronkerrnz/logstash-plugin-dev):
 
-- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+To start an interactive environment run:
 
-- Install dependencies
-```sh
-bundle install
+``` sh
+docker run --rm -it -v ${PWD}:/work cameronkerrnz/logstash-plugin-dev:7.9
 ```
 
-#### Test
+After that you can run the usual suspects:
 
-- Update your dependencies
-
+- Install/Update dependencies
 ```sh
 bundle install
 ```

--- a/lib/logstash/outputs/mongodb.rb
+++ b/lib/logstash/outputs/mongodb.rb
@@ -34,22 +34,46 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
   # "_id" field in the event.
   config :generateId, :validate => :boolean, :default => false
 
-
   # Bulk insert flag, set to true to allow bulk insertion, else it will insert events one by one.
   config :bulk, :validate => :boolean, :default => false
+
   # Bulk interval, Used to insert events periodically if the "bulk" flag is activated.
   config :bulk_interval, :validate => :number, :default => 2
+
   # Bulk events number, if the number of events to insert into a collection raise that limit, it will be bulk inserted
   # whatever the bulk interval value (mongodb hard limit is 1000).
   config :bulk_size, :validate => :number, :default => 900, :maximum => 999, :min => 2
 
-  # The method used to write processed events to MongoDB.
-  # Possible values are `insert`, `update` and `replace`.
-  config :action, :validate => :string, :required => true
-  # The key of the query to find the document to update or replace.
-  config :query_key, :validate => :string, :required => false, :default => "_id"
-  # The value of the query to find the document to update or replace. This can be dynamic using the `%{foo}` syntax.
-  config :query_value, :validate => :string, :required => false
+  # The Mongo DB action to perform. Valid actions are:
+  #
+  # - insert: inserts a document, fails if a document the document already exists.
+  # - update: updates a document given a `filter`. You can also upsert a document, see the `upsert` option.
+  # - delete: *Not Supported* at the moment
+  #
+  # A sprintf style string is allowed to change the action based on the content
+  # of the event. The value `%{[foo]}` would use the foo field for the action.
+  #
+  # For more details on actions, check out the https://docs.mongodb.com/ruby-driver/v2.6/tutorials/ruby-driver-bulk-operations[Mongo Ruby Driver documentation]
+  config :action, :validate => :string, :default => "insert"
+
+  # The value of the :filter clause for update or replace. A sprintf style
+  # string is allowed for either keys or values. The value `%{[foo]}` would use
+  # the foo field instead.
+  config :filter, :validate => :hash, :required => false, :default => {}
+
+  # The _first_ key/value in :update_expressions will be used *instead* of the
+  # default '$set' update operator. This option is useful for using alternative
+  # operators like '$inc'.
+  #
+  # A sprintf style string is allowed for values. The value `%{[foo]}` would use
+  # the foo field instead.
+  #
+  # Keys must start with `$`, see the https://docs.mongodb.com/manual/reference/operator/update/#id1[Mongo DB Update Operators] for reference.
+  #
+  # Note that while the name of the option is plural, passing a pipeline is not
+  # yet supported (Mongo >= 4.2). Only *the first* key/value will be used.
+  config :update_expressions, :validate => :hash, :required => false, :default => nil
+
   # If true, a new document is created if no document exists in DB with given `document_id`.
   # Only applies if action is `update` or `replace`.
   config :upsert, :validate => :boolean, :required => false, :default => false
@@ -88,20 +112,37 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
     if @bulk_size > 1000
       raise LogStash::ConfigurationError, "Bulk size must be lower than '1000', currently '#{@bulk_size}'"
     end
-    if @action != "insert" && @action != "update" && @action != "replace"
-      raise LogStash::ConfigurationError, "Only insert, update and replace are valid for 'action' setting."
+    if !@update_expressions.nil?
+      @update_expressions.keys.each { |k|
+        if !is_update_operator(k)
+          raise LogStash::ConfigurationError, "The :update_expressions option contains '#{k}', which is not an Update expression."
+          break
+        end
+      }
     end
-    if (@action == "update" || @action == "replace") && (@query_value.nil? || @query_value.empty?)
-      raise LogStash::ConfigurationError, "If action is update or replace, query_value must be set."
+  end
+
+  def validate_action(action, filter, update_expressions)
+    if action != "insert" && action != "update" && action != "replace"
+      raise LogStash::ConfigurationError, "Only insert, update and replace are supported Mongo actions, got '#{action}'."
+    end
+    if (action == "update" || action == "replace") && (filter.nil? || filter.empty?)
+      raise LogStash::ConfigurationError, "If action is update or replace, filter must be set."
+    end
+    if action != "update" && !(update_expressions.nil? || update_expressions.empty?)
+      raise LogStash::ConfigurationError, "The :update_expressions only makes sense if the action is an update."
     end
   end
 
   def receive(event)
+    action = event.sprintf(@action)
+
+    validate_action(action, @filter, @update_expressions)
+
     begin
       # Our timestamp object now has a to_bson method, using it here
       # {}.merge(other) so we don't taint the event hash innards
       document = {}.merge(event.to_hash)
-
       if !@isodate
         timestamp = event.timestamp
         if timestamp
@@ -117,9 +158,19 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
       end
 
       collection = event.sprintf(@collection)
-      if @action == "update" or @action == "replace"
-        document["metadata_mongodb_output_query_value"] = event.sprintf(@query_value)
+      if action == "update" or action == "replace"
+        document["metadata_mongodb_output_filter"] = apply_event_to_hash(event, @filter)
       end
+
+      if action == "update" and !(@update_expressions.nil? || @update_expressions.empty?)
+        # we only expand the values cause keys are update expressions
+        expressions_hash = {}
+        @update_expressions.each do |k, v|
+          expressions_hash[k] = apply_event_to_hash(event, v)
+        end
+        document["metadata_mongodb_output_update_expressions"] = expressions_hash
+      end
+
       if @bulk
         @@mutex.synchronize do
           if(!@documents[collection])
@@ -144,32 +195,56 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
         # to fix the issue.
         @logger.warn("Skipping insert because of a duplicate key error", :event => event, :exception => e)
       else
-        @logger.warn("Failed to send event to MongoDB, retrying in #{@retry_delay.to_s} seconds", :event => event, :exception => e)
+        @logger.warn("Failed to send event to MongoDB retrying in #{@retry_delay.to_s} seconds", :event => event, :exception => e)
         sleep(@retry_delay)
-        retry
+        # retry
       end
     end
   end
 
   def write_to_mongodb(collection, documents)
     ops = get_write_ops(documents)
+    @logger.debug("Sending", :ops => ops)
     @db[collection].bulk_write(ops)
   end
 
   def get_write_ops(documents)
     ops = []
     documents.each do |doc|
-      replaced_query_value = doc["metadata_mongodb_output_query_value"]
-      doc.delete("metadata_mongodb_output_query_value")
-      if @action == "insert"
+      filter = doc["metadata_mongodb_output_filter"]
+      doc.delete("metadata_mongodb_output_filter")
+
+      update_expressions = doc["metadata_mongodb_output_update_expressions"]
+      doc.delete("metadata_mongodb_output_update_expressions")
+
+      # TODO: support multiple expressions as pipeline for Mongo >= 4.2
+      update = if !update_expressions.nil?
+                 [update_expressions.first].to_h
+               else
+                 {'$set' => to_dotted_hash(doc)}
+               end
+
+      if action == "insert"
         ops << {:insert_one => doc}
-      elsif @action == "update"
-        ops << {:update_one => {:filter => {@query_key => replaced_query_value}, :update => {'$set' => to_dotted_hash(doc)}, :upsert => @upsert}}
-      elsif @action == "replace"
-        ops << {:replace_one => {:filter => {@query_key => replaced_query_value}, :replacement => doc, :upsert => @upsert}}
+      elsif action == "update"
+        ops << {:update_one => {:filter => filter, :update => update, :upsert => @upsert}}
+      elsif action == "replace"
+        ops << {:replace_one => {:filter => filter, :replacement => doc, :upsert => @upsert}}
       end
     end
     ops
+  end
+
+  def is_update_operator(string)
+    string.start_with?("$")
+  end
+
+  # Apply the event to the input hash keys and values.
+  # This function is not recursive (update operators don't accept nested hashes).
+  def apply_event_to_hash(event, hash)
+    hash.clone.each_with_object({}) do |(k, v), ret|
+      ret[event.sprintf(k)] = event.sprintf(v)
+    end
   end
 
   def to_dotted_hash(hash, recursive_key = "")

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/mongodb_spec.rb
+++ b/spec/integration/mongodb_spec.rb
@@ -6,8 +6,7 @@ describe LogStash::Outputs::Mongodb, :integration => true do
   let(:uri)        { 'mongodb://localhost:27017' }
   let(:database)   { 'logstash' }
   let(:collection) { 'logs' }
-  let(:uuid)       { SecureRandom.uuid }
-  let(:action) { 'insert' }
+  let(:action)     { 'insert' }
 
   let(:config) do
     { "uri" => uri, "database" => database,
@@ -19,8 +18,10 @@ describe LogStash::Outputs::Mongodb, :integration => true do
     subject { LogStash::Outputs::Mongodb.new(config) }
 
     let(:properties) { { "message" => "This is a message!",
-                         "uuid" => uuid, "number" => BigDecimal.new("4321.1234"),
-                         "utf8" => "żółć", "int" => 42,
+                         "uuid" => "00000000-0000-0000-0000-000000000000",
+                         "number" => BigDecimal.new("4321.1234"),
+                         "utf8" => "żółć",
+                         "int" => 42,
                          "arry" => [42, "string", 4321.1234]} }
     let(:event)      { LogStash::Event.new(properties) }
 

--- a/spec/outputs/mongodb_config_validation_spec.rb
+++ b/spec/outputs/mongodb_config_validation_spec.rb
@@ -8,28 +8,71 @@ describe LogStash::Outputs::Mongodb do
   let(:database) { 'logstash' }
   let(:collection) { 'logs' }
 
-  describe "validate_config method" do
+  describe "when validating config" do
 
     subject! { LogStash::Outputs::Mongodb.new(config) }
 
     [
-        {:action => "not-supported", :query_key => "qk", :query_value => "qv", :upsert => false,
-         :expected_reason => "Only insert, update and replace are valid for 'action' setting."},
-        {:action => "update", :query_key => "qk", :query_value => nil, :upsert => false,
-         :expected_reason => "If action is update or replace, query_value must be set."},
-        {:action => "update", :query_key => "qk", :query_value => "", :upsert => false,
-         :expected_reason => "If action is update or replace, query_value must be set."},
-        {:action => "replace", :query_key => "qk", :query_value => nil, :upsert => false,
-         :expected_reason => "If action is update or replace, query_value must be set."},
-        {:action => "replace", :query_key => "qk", :query_value => "", :upsert => false,
-         :expected_reason => "If action is update or replace, query_value must be set."},
+        {:update_expressions => {"invalid-expression" => "foo"},
+         :expected_reason => "The :update_expressions option contains 'invalid-expression', which is not an Update expression."},
         {:action => "insert", :bulk_size => 1001,
          :expected_reason => "Bulk size must be lower than '1000', currently '1001'"},
     ].each do |test|
 
-      describe "when validating config with action '#{test[:action]}' query_key '#{test[:query_key]}', query_value '#{test[:query_value]}' and upsert '#{test[:upsert]}'" do
+      describe "with :bulk_size => '#{test[:bulk_size]}', :upsert => '#{test[:upsert]}' and :update_expressions => '#{test[:update_expressions]}'" do
 
-        let(:config) {
+        let(:config) do
+          configuration = {
+              "uri" => uri,
+              "database" => database,
+              "collection" => collection,
+              "filter" => {"_id" => "123"},
+              "action" => "update"
+          }
+          unless test[:bulk_size].nil?
+            configuration["bulk_size"] = test[:bulk_size]
+          end
+          unless test[:update_expressions].nil?
+            configuration["update_expressions"] = test[:update_expressions]
+          end
+          return configuration
+        end
+
+        it "should raise error: '#{test[:expected_reason]}'" do
+          expect { subject.validate_config }.to raise_error(LogStash::ConfigurationError, test[:expected_reason])
+        end
+      end
+    end
+  end
+
+  describe "when validating action" do
+
+    subject! { LogStash::Outputs::Mongodb.new(config) }
+
+    [
+        {:action => "unsupported", :filter => {"_id" => "123"}, :upsert => false,
+         :expected_reason => "Only insert, update and replace are supported Mongo actions, got 'unsupported'."},
+        {:action => "delete", :filter => {"_id" => "123"}, :upsert => false,
+         :expected_reason => "Only insert, update and replace are supported Mongo actions, got 'delete'."},
+        {:action => "update", :filter => {}, :upsert => false,
+         :expected_reason => "If action is update or replace, filter must be set."},
+        {:action => "%{myaction}", :filter => {}, :upsert => false,
+         :expected_reason => "If action is update or replace, filter must be set."},
+        {:action => "%{[myactionnested][foo]}", :filter => {}, :upsert => false,
+         :expected_reason => "If action is update or replace, filter must be set."},
+        {:action => "update", :filter => nil, :upsert => false,
+         :expected_reason => "If action is update or replace, filter must be set."},
+        {:action => "insert", :update_expressions => {"$inc" => {"quantity" => 1}},
+         :expected_reason => "The :update_expressions only makes sense if the action is an update."},
+        {:action => "replace",  :filter => {"_id" => "123"}, :update_expressions => {"$inc" => {"quantity" => 1}},
+         :expected_reason => "The :update_expressions only makes sense if the action is an update."},
+    ].each do |test|
+
+      describe "with :action => '#{test[:action]}', :filter => '#{test[:filter]}', :upsert => '#{test[:upsert]}' and :update_expressions => '#{test[:update_expressions]}'" do
+
+        let(:event) { LogStash::Event.new("myaction" => "update", "myactionnested" => {"foo" => "replace"})}
+
+        let(:config) do
           configuration = {
               "uri" => uri,
               "database" => database,
@@ -38,27 +81,22 @@ describe LogStash::Outputs::Mongodb do
           unless test[:action].nil?
             configuration["action"] = test[:action]
           end
-          unless test[:query_key].nil?
-            configuration["query_key"] = test[:query_key]
-          end
-          unless test[:query_value].nil?
-            configuration["query_value"] = test[:query_value]
+          unless test[:filter].nil?
+            configuration["filter"] = test[:filter]
           end
           unless test[:upsert].nil?
             configuration["upsert"] = test[:upsert]
           end
-          unless test[:bulk_size].nil?
-            configuration["bulk_size"] = test[:bulk_size]
+          unless test[:update_expressions].nil?
+            configuration["update_expressions"] = test[:update_expressions]
           end
           return configuration
-        }
+        end
 
-        it "should raise error: #{test[:expected_reason]}" do
-          expect { subject.validate_config }.to raise_error(LogStash::ConfigurationError, test[:expected_reason])
+        it "should raise error: '#{test[:expected_reason]}'" do
+          expect { subject.receive(event) }.to raise_error(LogStash::ConfigurationError, test[:expected_reason])
         end
       end
-
     end
-
   end
 end

--- a/spec/outputs/mongodb_insert_spec.rb
+++ b/spec/outputs/mongodb_insert_spec.rb
@@ -45,7 +45,7 @@ describe LogStash::Outputs::Mongodb do
     describe "when processing an event" do
       let(:properties) {{
         "message" => "This is a message!",
-        "uuid" => SecureRandom.uuid,
+        "uuid" => "00000000-0000-0000-0000-000000000000",
         "number" => BigDecimal.new("4321.1234"),
         "utf8" => "żółć"
       }}

--- a/spec/outputs/mongodb_replace_spec.rb
+++ b/spec/outputs/mongodb_replace_spec.rb
@@ -21,7 +21,7 @@ describe LogStash::Outputs::Mongodb do
 
     let(:properties) { {
         "message" => "This is a message!",
-        "uuid" => SecureRandom.uuid,
+        "uuid" => "00000000-0000-0000-0000-000000000000",
         "number" => BigDecimal.new("4321.1234"),
         "utf8" => "żółć"
     } }
@@ -43,24 +43,18 @@ describe LogStash::Outputs::Mongodb do
     end
 
     [
-        {:query_key => nil, :query_value => "qv", :upsert => false,
-         :expected => {:query_key => "_id", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => false,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => nil,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => nil, :query_value => "qv", :upsert => true,
-         :expected => {:query_key => "_id", :query_value => "qv", :upsert => true}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => true,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => true}
-        },
+      {:filter => {"_id" => "%{uuid}"}, :upsert => false,
+       :expected => {:filter => {"_id" => "00000000-0000-0000-0000-000000000000"}, :upsert => false}
+      },
+      {:filter => {"%{utf8}" => "%{message}"}, :upsert => nil,
+       :expected => {:filter => {"żółć" => "This is a message!"}, :upsert => false}
+      },
+      {:filter => {"%{utf8}" => "%{message}"}, :upsert => true,
+       :expected => {:filter => {"żółć" => "This is a message!"}, :upsert => true}
+      },
     ].each do |test|
 
-      describe "when processing an event with query_key set to '#{test[:query_key]}', query_value set to '#{test[:query_value]}' and upsert set to '#{test[:upsert]}'" do
+      describe "when processing an event with :filter => '#{test[:filter]}' and :upsert => '#{test[:upsert]}'" do
 
         let(:config) {
           configuration = {
@@ -69,11 +63,8 @@ describe LogStash::Outputs::Mongodb do
               "collection" => collection,
               "action" => action
           }
-          unless test[:query_key].nil?
-            configuration["query_key"] = test[:query_key]
-          end
-          unless test[:query_value].nil?
-            configuration["query_value"] = test[:query_value]
+          unless test[:filter].nil?
+            configuration["filter"] = test[:filter]
           end
           unless test[:upsert].nil?
             configuration["upsert"] = test[:upsert]
@@ -82,11 +73,11 @@ describe LogStash::Outputs::Mongodb do
         }
 
         expected = test[:expected]
-        it "should send that document as a replace to mongodb with query_key '#{expected[:query_key]}', query_value '#{expected[:query_value]}' and upsert '#{expected[:upsert]}'" do
+        it "should send that document as a replace to mongodb with :filter => '#{expected[:filter]}' and upsert => '#{expected[:upsert]}'" do
           expect(event).to receive(:timestamp).and_return(nil)
           expect(event).to receive(:to_hash).and_return(properties)
           expect(collection).to receive(:bulk_write).with(
-              [{:replace_one => {:filter => {expected[:query_key] => expected[:query_value]}, :replacement => properties, :upsert => expected[:upsert]}}]
+              [{:replace_one => {:filter => expected[:filter], :replacement => properties, :upsert => expected[:upsert]}}]
           )
           subject.receive(event)
         end

--- a/spec/outputs/mongodb_update_nested_fields_spec.rb
+++ b/spec/outputs/mongodb_update_nested_fields_spec.rb
@@ -8,14 +8,14 @@ describe LogStash::Outputs::Mongodb do
   let(:database) { 'logstash' }
   let(:collection) { 'logs' }
   let(:action) { 'update' }
-  let(:query_value) { 'qv' }
+  let(:filter) { {"_id" => 'foo' } }
 
   let(:config) { {
       "uri" => uri,
       "database" => database,
       "collection" => collection,
       "action" => action,
-      "query_value" => query_value
+      "filter" => filter,
   } }
 
   describe "receive method while action is 'update'" do
@@ -64,7 +64,7 @@ describe LogStash::Outputs::Mongodb do
         expect(event).to receive(:timestamp).and_return(nil)
         expect(event).to receive(:to_hash).and_return(properties)
         expect(collection).to receive(:bulk_write).with(
-            [{:update_one => {:filter => {"_id" => query_value}, :update => {"$set" => {
+            [{:update_one => {:filter => {"_id" => 'foo' }, :update => {"$set" => {
                 "message" => "This is a message!",
                 "rootHashField.numFieldInHash" => 1,
                 "rootHashField.hashFieldInHash.numField" => 2,

--- a/spec/outputs/mongodb_update_spec.rb
+++ b/spec/outputs/mongodb_update_spec.rb
@@ -4,7 +4,7 @@ require "logstash/plugin"
 
 describe LogStash::Outputs::Mongodb do
 
-  let(:uri) { 'mongodb://localhost:27017' }
+  let(:uri) { 'mongodb://mongo:27017' }
   let(:database) { 'logstash' }
   let(:collection) { 'logs' }
   let(:action) { 'update' }
@@ -21,8 +21,9 @@ describe LogStash::Outputs::Mongodb do
 
     let(:properties) { {
         "message" => "This is a message!",
-        "uuid" => SecureRandom.uuid,
+        "uuid" => "00000000-0000-0000-0000-000000000000",
         "number" => BigDecimal.new("4321.1234"),
+        "integer" => 1,
         "utf8" => "żółć"
     } }
     let(:event) { LogStash::Event.new(properties) }
@@ -43,25 +44,21 @@ describe LogStash::Outputs::Mongodb do
     end
 
     [
-        {:query_key => nil, :query_value => "qv", :upsert => false,
-         :expected => {:query_key => "_id", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => false,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => nil,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => false}
-        },
-        {:query_key => nil, :query_value => "qv", :upsert => true,
-         :expected => {:query_key => "_id", :query_value => "qv", :upsert => true}
-        },
-        {:query_key => "qk", :query_value => "qv", :upsert => true,
-         :expected => {:query_key => "qk", :query_value => "qv", :upsert => true}
-        },
+      {:filter => {"_id" => "123"}, :upsert => false,
+       :expected => {:filter => {"_id" => "123"}, :upsert => false}
+      },
+      {:filter => {"%{utf8}" => "%{message}"}, :upsert => nil,
+       :expected => {:filter => {"żółć" => "This is a message!"}, :upsert => false}
+      },
+      {:filter => {"%{utf8}" => "%{message}"}, :upsert => true,
+       :expected => {:filter => {"żółć" => "This is a message!"}, :upsert => true}
+      },
+      {:filter => {"_id" => "%{uuid}"}, :update_expressions => {"$inc" => {"quantity" => "%{integer}"}, "$rename" => {"%{utf8}" => "foo"}},
+       :expected => {:filter => {"_id" => "00000000-0000-0000-0000-000000000000"}, :update_expressions => {"$inc" => {"quantity" => "1"}, "$rename" => {"żółć" => "foo"}}, :upsert => false}
+      },
     ].each do |test|
 
-      describe "when processing an event with query_key set to '#{test[:query_key]}', query_value set to '#{test[:query_value]}' and upsert set to '#{test[:upsert]}'" do
-
+      describe "when processing an event with :filter => '#{test[:filter]}', :upsert => '#{test[:upsert]}' and merge :update and :update_expressions}'" do
         let(:config) {
           configuration = {
               "uri" => uri,
@@ -69,25 +66,34 @@ describe LogStash::Outputs::Mongodb do
               "collection" => collection,
               "action" => action
           }
-          unless test[:query_key].nil?
-            configuration["query_key"] = test[:query_key]
-          end
-          unless test[:query_value].nil?
-            configuration["query_value"] = test[:query_value]
+          unless test[:filter].nil?
+            configuration["filter"] = test[:filter]
           end
           unless test[:upsert].nil?
             configuration["upsert"] = test[:upsert]
+          end
+          unless test[:update_expressions].nil?
+            configuration["update_expressions"] = test[:update_expressions]
           end
           return configuration
         }
 
         expected = test[:expected]
-        it "should send that document as an update to mongodb with query_key '#{expected[:query_key]}', query_value '#{expected[:query_value]}' and upsert '#{expected[:upsert]}'" do
+        it "should send that document as an update to mongodb with :filter => '#{expected[:filter]}', :upsert => '#{expected[:upsert]}' and :update_expressions => '#{expected[:update_expressions]}'" do
+
           expect(event).to receive(:timestamp).and_return(nil)
           expect(event).to receive(:to_hash).and_return(properties)
+
+          update = if !expected[:update_expressions].nil?
+                     [expected[:update_expressions].first].to_h
+                   else
+                     {"$set" => properties}
+                   end
+
           expect(collection).to receive(:bulk_write).with(
-              [{:update_one => {:filter => {expected[:query_key] => expected[:query_value]}, :update => {"$set" => properties}, :upsert => expected[:upsert]}}]
-          )
+                                  [{:update_one => {:filter => expected[:filter],
+                                                    :update => update,
+                                                    :upsert => expected[:upsert]}}])
           subject.receive(event)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/mongodb"
 
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = 'spec/test-report.txt'
+end
+
 RSpec::Matchers.define :have_received do |event|
   match do |subject|
     client     = subject.instance_variable_get("@db")


### PR DESCRIPTION
This commit introduces :filter (instead of :query-key and :query-value) for
defining the query that we pass down to Mongo. It is a hash and will allow us
to filter by a composite key.

In addition to that :update_expressions is now another optional hash that can
be added if the action is an update.

The first key/value can be a Mongo Update
Expression (https://docs.mongodb.com/manual/reference/operator/update/#id1) and
the values substituted as usual. Note that pipeline (Mongo >= 4.2) support is
not there yet.

The :update_expression hash will *replace* the $set operator that includes the
logstash event itself.

On top of it all, now action is fully dynamic and expanded via sprintf as in
logstash-output-elasticsearch.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
